### PR TITLE
🐞 fix(car): fix abrupt car stop after speed boost end when the car is off bounds

### DIFF
--- a/prefabs/car_custom_physics_2.gd
+++ b/prefabs/car_custom_physics_2.gd
@@ -200,6 +200,8 @@ func _soft_clamp_speed(state: PhysicsDirectBodyState3D, out_of_bounds: bool):
 	var max_speed_squared = _get_max_speed_squared(out_of_bounds)
 	if (vel_squared_xz > max_speed_squared):
 		var norm_projected_on_xz: Vector3 = state.linear_velocity.normalized() * Vector3(1, 0, 1)
+		# Capping to half the current speed to avoid abrupt changes (like straight up stopping
+		# the car after a speed boost end while being out of bounds in "crazy" speed mode (~40m/s)).
 		var diff: float = min(vel_squared_xz * 0.5, vel_squared_xz - max_speed_squared)
 		# This is a physics based "clamp", being quadratic to be as close as possible to a hard limit.
 		# We do not use clamp as it causes unexpected behavior, such as making the car drift in air.


### PR DESCRIPTION
This only happened in modes with the highest speeds.

closes #165 